### PR TITLE
Fix type inference for polymorphic functions with HasField in lists

### DIFF
--- a/tests/type_system/hasfield_polymorphic_list.nos
+++ b/tests/type_system/hasfield_polymorphic_list.nos
@@ -1,0 +1,25 @@
+# expect: true
+# Regression test: HasField constraints on polymorphic functions stored in lists.
+# When multiple helper functions access the same record field (.value) and are
+# stored in a list as first-class values, duplicate HasField constraints must
+# be deduplicated to avoid incorrect unification failures.
+type Cell = { value: Int }
+cell_out() = Cell(-1)
+is_out(cell) = cell.value == -1
+cell_row(cell) = if cell.value == -1 then -1 else cell.value / 6
+cell_col(cell) = if cell.value == -1 then -1 else cell.value % 6
+cell_for_coords(row, col) = if row < 0 || col < 0 then cell_out() else Cell(row * 6 + col)
+neighbour_left(cell) = if is_out(cell) then cell_out() else cell_for_coords(cell_row(cell), cell_col(cell) - 1)
+neighbour_right(cell) = if is_out(cell) then cell_out() else cell_for_coords(cell_row(cell), cell_col(cell) + 1)
+valid_jumps() = [neighbour_left, neighbour_right]
+check_jump(from_cell, target, jumps) = {
+    if jumps.isEmpty() then false
+    else {
+        jump_fn = head(jumps)
+        rest = tail(jumps)
+        if jump_fn(from_cell) == target then true
+        else check_jump(from_cell, target, rest)
+    }
+}
+can_jump_over(from_cell: Cell, target: Cell) = check_jump(from_cell, target, valid_jumps())
+main() = can_jump_over(Cell(0), Cell(1))


### PR DESCRIPTION
Closing in favor of direct fix on master (649b963). The core idea (deduplicating HasField constraints by var_id + field_name) was applied with a simplified implementation using HashSet instead of HashMap. Thanks for the contribution!

## Summary
- Fix duplicate HasField constraints causing "expected Int, found Cell" when polymorphic functions accessing record fields are stored in lists as first-class values
- Deduplicate HasField constraints by `(resolved_var_id, field_name)` in signature encoding, emitting only one bound per pair
- Add regression test `tests/type_system/hasfield_polymorphic_list.nos`

## Test plan
- [x] `/tmp/hasfield_bug.nos` compiles and runs successfully (new binary)
- [x] Baseline binary still fails with "expected Int, found Cell"
- [x] New regression test passes
- [x] Full test suite: 1414 passed, 0 failed
- [x] All 1626 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)