### PR TITLE
Add regression test for UFCS list.contains in cross-module context

### DIFF
--- a/tests/cross_module/ufcs_list_contains_multimodule.nos
+++ b/tests/cross_module/ufcs_list_contains_multimodule.nos
@@ -1,0 +1,23 @@
+# expect: [Alice!]
+# Cross-module UFCS list.contains regression test.
+# Previously, when a record type with a List[String] field was imported
+# from another module, calling .contains() on that list via UFCS
+# would resolve to String.contains instead of stdlib.list.contains,
+# causing "type mismatch: expected Bool, found String".
+
+module Types
+    pub type Box = { items: List[String] }
+end
+
+use Types.*
+
+process(boxes, names) =
+    boxes.flatMap(b => {
+        own = b.items.filter(v => names.contains(v))
+        own.map(v => v ++ "!")
+    })
+
+main() = {
+    result = process([Box(["Alice", "Bob"])], ["Alice"])
+    show(result)
+}


### PR DESCRIPTION
## Summary
- Adds a regression test for a UFCS bug where `.contains()` on a `List[String]` field from an imported record type resolved to `String.contains` instead of `stdlib.list.contains`
- The bug was triggered when combining cross-module record imports, field access, `.filter()` with `.contains()`, `.map()` chaining, and `.flatMap()` wrapping
- The bug has been fixed by recent upstream changes (likely `d722faa1` and related commits), this test prevents regression

## Minimal reproduction (previously failed)
```nostos
module Types
    pub type Box = { items: List[String] }
end

use Types.*

process(boxes, names) =
    boxes.flatMap(b => {
        own = b.items.filter(v => names.contains(v))
        own.map(v => v ++ "!")
    })

main() = {
    result = process([Box(["Alice", "Bob"])], ["Alice"])
    show(result)
}
```

**Previous error:** `type mismatch: expected Bool, found String`
**Expected output:** `[Alice!]`

## Workaround (for older versions)
Use explicit function call instead of UFCS: `contains(names, v)` instead of `names.contains(v)`

## Test plan
- [x] New test passes: `./target/release/nostos tests/cross_module/ufcs_list_contains_multimodule.nos` → `[Alice!]`
- [x] All cross_module tests pass (5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)