### PR TITLE
Fix __dispatch_contains to use structural equality for all types

### DIFF
--- a/crates/vm/src/async_vm.rs
+++ b/crates/vm/src/async_vm.rs
@@ -13959,19 +13959,12 @@ impl AsyncVM {
                     }
                     GcValue::List(list) => {
                         let needle = &args[1];
-                        // For string elements, compare by content (not pointer)
-                        // since GcValue::PartialEq for String only compares GcPtr
-                        let needle_str = if let GcValue::String(ptr) = needle {
-                            heap.get_string(*ptr).map(|s| s.data.clone())
-                        } else {
-                            None
-                        };
+                        // Use gc_values_equal for structural equality (not pointer equality).
+                        // GcValue::PartialEq compares GcPtr indices, which fails for
+                        // heap-allocated values (records, strings) with identical content
+                        // but different allocations.
                         let found = list.iter().any(|item| {
-                            if let (Some(ref ns), GcValue::String(item_ptr)) = (&needle_str, item) {
-                                heap.get_string(*item_ptr).map(|s| s.data == *ns).unwrap_or(false)
-                            } else {
-                                item == needle
-                            }
+                            heap.gc_values_equal(item, needle)
                         });
                         Ok(GcValue::Bool(found))
                     }


### PR DESCRIPTION
## Summary

`__dispatch_contains` (the runtime-dispatch fallback for `.contains()` called from lambdas) used `GcValue::PartialEq` to compare list elements with the needle. For heap-allocated types, `PartialEq` compares `GcPtr` indices (pointer identity), not structural content. This means two records with identical field values but allocated at different times compare as **not equal**, causing `.contains()` to silently return `false`.

The existing code already had a workaround for strings (lines 13998–14008, comparing string content instead of `GcPtr`), but all other heap-allocated types still used pointer equality:

- **Record** / **Variant** — the case that triggered the bug
- **Array** / **Tuple** / **Map** / **Set**
- **BigInt** / **Closure**

## The fix

Replace both the string special-case and the `item == needle` fallback with a single call to `heap.gc_values_equal(item, needle)`, which performs deep structural comparison for all types. This matches the behaviour of:
- The `Eq` bytecode instruction (line 3630)
- The stdlib `contains[T]` function (which uses `==` → `Eq` instruction → `gc_values_equal`)

## When does `__dispatch_contains` get used?

The compiler emits `__dispatch_contains` instead of the monomorphized stdlib `contains` when `.contains()` is called inside a lambda (`current_function_name` is `None`) and the HM type for the receiver object is not resolved (`compile.rs` lines 15693–15714 and 15724–15737). This happens when type inference is confused by unrelated untyped functions in the same file.

## How to reproduce

Save the following as `repro.nos` and run with `nostos repro.nos`:

```nostos
# Nostos bug: .contains() returns wrong result due to type inference interaction
#
# SUMMARY:
#   .contains() on a list produced by flatMap+filter returns false for elements
#   that ARE present. The bug is triggered by the presence of an unrelated, UNUSED
#   function with an untyped parameter that accesses .value (a field shared with
#   the Cell record type used in the flatMap chain).
#
# EXPECTED: test_opponent_cells_jumped_over passes (result length == 1)
# ACTUAL:   test_opponent_cells_jumped_over fails  (result length == 0)
#
# FIXES (any one of these):
#   - Add type annotation: change `unused_fn(cell) = cell.value` to
#     `unused_fn(cell: Cell) = cell.value`
#   - Remove the unused function entirely
#   - Use .any(o => o.value == c.value) instead of .contains(c)
#
# REQUIREMENTS FOR BUG TO MANIFEST:
#   1. A flatMap+filter chain producing a list of Cell records
#   2. .contains() called on that list (inside a nested .filter() lambda)
#   3. An untyped function accessing .value somewhere in the file (even if unused)
#   4. Both tests evaluated in the same list literal (second test uses
#      colour_positions directly, not through flatMap)

use stdlib.list.{Option, Some, None, count}

type Colour = Red | Green | Blue
type Cell = { value: Int }
type Pawn = { value: Int }
type Move = Pass | Score(Int) | Board(Pawn, List[Cell])
type BoardPositions = { red: List[Int], green: List[Int], blue: List[Int] }
type GameState = { colourInTurn: Colour, scoreBoard: List[Int], board: BoardPositions }

cell_out() = Cell(-1)
is_out(cell) = cell.value == -1
is_on_board(cell) = cell.value >= 0 && cell.value <= 20
highest_cell_number = 20
cells_before_row(row) = cells_before_row(row - 1) + (7 - row)
cell_at(row, col) = Cell(cells_before_row(row) + col)
cell_row(cell) = if is_out(cell) then -1 else find_row(cell.value, 0)
find_row(v, r) = if r > 5 then -1 else if v < 6 - r then r else find_row(v - (6 - r), r + 1)
cell_col(cell) = if is_out(cell) then -1 else find_col(cell.value, 0)
find_col(v, r) = if r > 5 then -1 else if v < 6 - r then v else find_col(v - (6 - r), r + 1)
rightmost_column_for_row(row) = 5 - row
coords_are_out(row, col) = row < 0 || row > 5 || col < 0 || col > rightmost_column_for_row(row)
cell_for_coords(row, col) = if coords_are_out(row, col) then cell_out() else cell_at(row, col)
neighbour_right(cell) = if is_out(cell) then cell_out() else cell_for_coords(cell_row(cell), cell_col(cell) + 1)
neighbour_up_left(cell) = if is_out(cell) then cell_out() else cell_for_coords(cell_row(cell) + 1, cell_col(cell) - 1)
neighbour_up_right(cell) = if is_out(cell) then cell_out() else cell_for_coords(cell_row(cell) + 1, cell_col(cell))

list_max_by([x], _) = x
list_max_by([x | rest], f) = {
    best = list_max_by(rest, f)
    if f(x) > f(best) then x else best
}
insert_sorted(elem, [h | t], f) =
    if f(elem) <= f(h) then [elem, h | t]
    else [h | insert_sorted(elem, t, f)]
insert_sorted_desc(elem, [h | t], f) =
    if f(elem) >= f(h) then [elem, h | t]
    else [h | insert_sorted_desc(elem, t, f)]

distance(from_cell: Cell, to_cell: Cell) = abs(cell_row(from_cell) - cell_row(to_cell)) + abs(cell_col(from_cell) - cell_col(to_cell))

all_colours() = [Red, Green, Blue]
opponent_colours(state: GameState) = all_colours().filter(c => c != state.colourInTurn)
colour_index(Red) = 0
colour_index(Green) = 1
colour_index(Blue) = 2
colour_positions(state: GameState, Red) = state.board.red.map(v => Cell(v))
colour_positions(state: GameState, Green) = state.board.green.map(v => Cell(v))
colour_positions(state: GameState, Blue) = state.board.blue.map(v => Cell(v))
colour_in_turn_positions_on_board(state: GameState) =
    colour_positions(state, state.colourInTurn).filter(c => is_on_board(c))
opponents_on_board(state: GameState) = {
    opp_colours = opponent_colours(state)
    opp_colours.flatMap(colour => colour_positions(state, colour)).filter(c => is_on_board(c))
}

is_board_move(Board(_, _)) = true
get_destinations(Board(_, dests)) = dests
get_destinations(_) = []
last_destination(move) = {
    dests = get_destinations(move)
    if dests.isEmpty() then cell_out() else dests[dests.length() - 1]
}

board_moves(moves) = moves.filter(m => is_board_move(m))
moves_staying_on_board(moves) = board_moves(moves).filter(m => {
    dests = get_destinations(m)
    is_on_board(dests[dests.length() - 1])
})

# *** BUG TRIGGER ***
# This function is NEVER CALLED. But its presence corrupts .contains().
# Fix: add type annotation -> unused_trigger(cell: Cell) = cell.value != 20
unused_trigger(cell) = cell.value != 20

cells_jumped_over(move) = {
    dests = get_destinations(move)
    if dests.length() <= 1 then []
    else get_even_indexed(dests, 0)
}
get_even_indexed(list, idx) = {
    if idx >= list.length() - 1 then []
    else [list[idx]] ++ get_even_indexed(list, idx + 2)
}
opponent_cells_jumped_over(move: Move, state: GameState) = {
    jumped = cells_jumped_over(move)
    opps = opponents_on_board(state)
    jumped.filter(c => opps.contains(c))  # <-- .contains() returns false incorrectly
}

is_safe_from(cell, opponents) = !opponents.any(opp => distance(cell, opp) <= 1)
safe_moves_away_from(moves, opponents) =
    moves_staying_on_board(moves).filter(m => is_safe_from(last_destination(m), opponents))

find_score_leader_colour(state: GameState) = {
    opp_colours = opponent_colours(state)
    list_max_by(opp_colours, c => state.scoreBoard[colour_index(c)])
}
score_leader_cells(state: GameState) = {
    leader = find_score_leader_colour(state)
    colour_positions(state, leader).filter(c => is_on_board(c))
}
score_leader_highest_cell(state: GameState) = {
    cells = score_leader_cells(state)
    if cells.isEmpty() then None()
    else Some(list_max_by(cells, c => cell_row(c)))
}

run_test(name, result) = {
    symbol = if result then "  ✅ " else "  ❌ "
    println(symbol ++ name)
    result
}

test_opponent_cells_jumped_over() = {
    state = GameState(Red, [0, 0, 0], BoardPositions([0, -1, -1], [1, -1, -1], [-1, -1, -1]))
    m = Board(Pawn(0), [Cell(1), Cell(2)])
    jumped = opponent_cells_jumped_over(m, state)
    jumped.length() == 1
}

test_score_leader_highest_cell() = {
    state = GameState(Green, [50, 30, 20], BoardPositions([0, 11, -1], [-1, -1, -1], [-1, -1, -1]))
    result = score_leader_highest_cell(state)
    match result {
        Some(cell) -> cell_row(cell) == 2
        None() -> false
    }
}

main() = {
    results = [
        run_test("test_opponent_cells_jumped_over", test_opponent_cells_jumped_over()),
        run_test("test_score_leader_highest_cell", test_score_leader_highest_cell())
    ]
    passed = count(results, x => x)
    total = results.length()
    println("Tests: " ++ show(total) ++ ", Passed: " ++ show(passed) ++ ", Failed: " ++ show(total - passed))
}
```

**Before fix:**
```
  ❌ test_opponent_cells_jumped_over
  ✅ test_score_leader_highest_cell
Tests: 2, Passed: 1, Failed: 1
```

**After fix:**
```
  ✅ test_opponent_cells_jumped_over
  ✅ test_score_leader_highest_cell
Tests: 2, Passed: 2, Failed: 0
```

## Root cause analysis

The bug has two contributing factors:

1. **Compiler-side (not fixed in this PR):** When `.contains()` is called inside a lambda and type inference doesn't resolve the HM type for the receiver (which can happen when untyped functions with `.value` access confuse the inference), the compiler falls back to `__dispatch_contains` instead of the monomorphized stdlib `contains[T]`.

2. **Runtime-side (fixed in this PR):** `__dispatch_contains` used `GcValue::PartialEq` for the element comparison. `GcValue::PartialEq` delegates to `GcPtr::PartialEq` for heap-allocated types, which compares heap indices (pointer identity). The stdlib `contains[T]` uses the `==` operator which compiles to the `Eq` bytecode instruction, which calls `gc_values_equal()` (structural equality). This inconsistency means the two code paths give different results for records with identical content but different heap allocations.

## Note on remaining compiler-side issue

Even with this fix, there is a separate issue where the compiler unnecessarily falls back to `__dispatch_contains` when type inference is confused. This doesn't cause incorrect results anymore (since `__dispatch_contains` now uses structural equality), but it is a less efficient code path. That compiler-side issue is not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)