### PR TITLE
Add WebSocket.connectWithHeaders for custom upgrade headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,12 @@ handle(req) = {
 ws = WebSocket.connect("wss://echo.websocket.org")
 WebSocket.send(ws, "Hello!")
 response = WebSocket.recv(ws)
+
+# Client with custom HTTP headers on the upgrade (e.g. X-API-Key, Authorization)
+ws = WebSocket.connectWithHeaders("wss://api.example.com/feed", [
+    ("X-API-Key", "secret"),
+    ("Authorization", "Bearer abc123"),
+])
 ```
 
 ### Cryptography

--- a/crates/compiler/src/compile.rs
+++ b/crates/compiler/src/compile.rs
@@ -614,6 +614,7 @@ pub const BUILTINS: &[BuiltinInfo] = &[
     BuiltinInfo { name: "WebSocket.isUpgrade", signature: "HttpRequest -> Bool", doc: "Check if request is a WebSocket upgrade request" },
     BuiltinInfo { name: "WebSocket.accept", signature: "Int -> WebSocket", doc: "Accept WebSocket upgrade for request ID, returns WebSocket handle" },
     BuiltinInfo { name: "WebSocket.connect", signature: "String -> WebSocket", doc: "Connect to WebSocket server at URL, returns WebSocket handle" },
+    BuiltinInfo { name: "WebSocket.connectWithHeaders", signature: "String -> [(String, String)] -> WebSocket", doc: "Connect to WebSocket server with custom HTTP headers on the upgrade request (e.g. for X-API-Key or Authorization)" },
     BuiltinInfo { name: "WebSocket.send", signature: "WebSocket -> String -> ()", doc: "Send message on WebSocket handle" },
     BuiltinInfo { name: "WebSocket.recv", signature: "WebSocket -> String", doc: "Receive message from WebSocket handle (blocks until message arrives)" },
     BuiltinInfo { name: "WebSocket.close", signature: "WebSocket -> ()", doc: "Close WebSocket connection" },
@@ -12616,6 +12617,13 @@ impl Compiler {
                             self.chunk.emit(Instruction::WebSocketConnect(dst, url_reg), line);
                             return Ok(dst);
                         }
+                        "WebSocket.connectWithHeaders" if args.len() == 2 => {
+                            let url_reg = self.compile_expr_tail(Self::call_arg_expr(&args[0]), false)?;
+                            let headers_reg = self.compile_expr_tail(Self::call_arg_expr(&args[1]), false)?;
+                            let dst = self.alloc_reg();
+                            self.chunk.emit(Instruction::WebSocketConnectWithHeaders(dst, url_reg, headers_reg), line);
+                            return Ok(dst);
+                        }
                         "WebSocket.send" if args.len() == 2 => {
                             let request_id_reg = self.compile_expr_tail(Self::call_arg_expr(&args[0]), false)?;
                             let message_reg = self.compile_expr_tail(Self::call_arg_expr(&args[1]), false)?;
@@ -13721,6 +13729,13 @@ impl Compiler {
                             let url_reg = self.compile_expr_tail(Self::call_arg_expr(&args[0]), false)?;
                             let dst = self.alloc_reg();
                             self.chunk.emit(Instruction::WebSocketConnect(dst, url_reg), line);
+                            return Ok(dst);
+                        }
+                        "WebSocket.connectWithHeaders" if args.len() == 2 => {
+                            let url_reg = self.compile_expr_tail(Self::call_arg_expr(&args[0]), false)?;
+                            let headers_reg = self.compile_expr_tail(Self::call_arg_expr(&args[1]), false)?;
+                            let dst = self.alloc_reg();
+                            self.chunk.emit(Instruction::WebSocketConnectWithHeaders(dst, url_reg, headers_reg), line);
                             return Ok(dst);
                         }
                         "WebSocket.send" if args.len() == 2 => {

--- a/crates/vm/src/async_vm.rs
+++ b/crates/vm/src/async_vm.rs
@@ -8161,6 +8161,72 @@ impl AsyncProcess {
                 }
             }
 
+            WebSocketConnectWithHeaders(dst, url_reg, headers_reg) => {
+                let url = match reg!(url_reg) {
+                    GcValue::String(ptr) => {
+                        self.heap.get_string(ptr).map(|s| s.data.clone())
+                            .ok_or_else(|| RuntimeError::IOError("Invalid URL string".to_string()))?
+                    }
+                    _ => return Err(RuntimeError::TypeError {
+                        expected: "String".to_string(),
+                        found: "non-string".to_string(),
+                    }),
+                };
+                let headers = match reg!(headers_reg) {
+                    GcValue::List(list) => {
+                        let mut result = Vec::new();
+                        for item in list.iter() {
+                            if let GcValue::Tuple(ptr) = item {
+                                if let Some(tuple) = self.heap.get_tuple(*ptr) {
+                                    if tuple.items.len() >= 2 {
+                                        let name = match &tuple.items[0] {
+                                            GcValue::String(ptr) => self.heap.get_string(*ptr)
+                                                .map(|s| s.data.clone())
+                                                .unwrap_or_default(),
+                                            _ => String::new(),
+                                        };
+                                        let value = match &tuple.items[1] {
+                                            GcValue::String(ptr) => self.heap.get_string(*ptr)
+                                                .map(|s| s.data.clone())
+                                                .unwrap_or_default(),
+                                            _ => String::new(),
+                                        };
+                                        result.push((name, value));
+                                    }
+                                }
+                            }
+                        }
+                        result
+                    }
+                    GcValue::Unit => vec![],
+                    _ => return Err(RuntimeError::TypeError {
+                        expected: "List[(String, String)]".to_string(),
+                        found: "non-list".to_string(),
+                    }),
+                };
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                if let Some(sender) = &self.shared.io_sender {
+                    let request = IoRequest::WebSocketConnectWithHeaders { url, headers, response: tx };
+                    if sender.send(request).is_err() {
+                        return Err(RuntimeError::IOError("IO runtime shutdown".to_string()));
+                    }
+                    let result = rx.await.map_err(|_| RuntimeError::IOError("IO response channel closed".to_string()))?;
+                    match result {
+                        Ok(IoResponseValue::Int(ws_handle)) => {
+                            set_reg!(dst, GcValue::Int64(ws_handle));
+                        }
+                        Ok(_) => {
+                            return Err(RuntimeError::IOError("Unexpected response type".to_string()));
+                        }
+                        Err(e) => {
+                            self.throw_exception("websocket_error", format!("{}", e))?;
+                        }
+                    }
+                } else {
+                    return Err(RuntimeError::IOError("IO runtime not available".to_string()));
+                }
+            }
+
             WebSocketSend(dst, request_id_reg, message_reg) => {
                 let request_id = match reg!(request_id_reg) {
                     GcValue::Int64(n) => n as u64,

--- a/crates/vm/src/io_runtime.rs
+++ b/crates/vm/src/io_runtime.rs
@@ -15,6 +15,11 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+// Shared counter for client-side WebSocket handles. Both `WebSocket.connect`
+// and `WebSocket.connectWithHeaders` allocate from this counter so handles
+// remain unique across the two code paths (they share the same connection map).
+static WS_CLIENT_COUNTER: AtomicU64 = AtomicU64::new(1000000);
+
 use chrono::Timelike;
 use std::future::poll_fn;
 use tokio::runtime::Runtime;
@@ -405,6 +410,12 @@ pub enum IoRequest {
     /// Connect to a WebSocket server
     WebSocketConnect {
         url: String,
+        response: IoResponse,
+    },
+    /// Connect to a WebSocket server with custom HTTP headers on the upgrade
+    WebSocketConnectWithHeaders {
+        url: String,
+        headers: Vec<(String, String)>,
         response: IoResponse,
     },
     /// Send a message on a WebSocket connection
@@ -1469,14 +1480,74 @@ impl IoRuntime {
                                 let (sender, receiver) = ws_stream.split();
 
                                 // Generate a unique handle for this connection
-                                use std::sync::atomic::{AtomicU64, Ordering};
-                                static WS_CLIENT_COUNTER: AtomicU64 = AtomicU64::new(1000000);
                                 let handle = WS_CLIENT_COUNTER.fetch_add(1, Ordering::SeqCst);
 
                                 // Store the connection
                                 ws_client_conns.lock().await.insert(handle, (sender, receiver));
 
                                 // Return the handle
+                                let _ = response.send(Ok(IoResponseValue::Int(handle as i64)));
+                            }
+                            Err(e) => {
+                                let _ = response.send(Err(IoError::IoError(format!("WebSocket connect failed: {}", e))));
+                            }
+                        }
+                    });
+                }
+
+                IoRequest::WebSocketConnectWithHeaders { url, headers, response } => {
+                    let ws_client_conns = ws_client_connections.clone();
+                    tokio::spawn(async move {
+                        use tokio_tungstenite::connect_async;
+                        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+                        use tokio_tungstenite::tungstenite::http::HeaderName;
+                        use tokio_tungstenite::tungstenite::http::HeaderValue;
+
+                        // Build the upgrade request from the URL, then attach headers.
+                        // IntoClientRequest fills in the standard WS handshake headers
+                        // (Host, Upgrade, Connection, Sec-WebSocket-Key/Version, ...)
+                        // so we just append the user-supplied ones on top.
+                        let mut request = match url.as_str().into_client_request() {
+                            Ok(req) => req,
+                            Err(e) => {
+                                let _ = response.send(Err(IoError::IoError(
+                                    format!("WebSocket connect failed: invalid URL: {}", e),
+                                )));
+                                return;
+                            }
+                        };
+                        let req_headers = request.headers_mut();
+                        for (name, value) in &headers {
+                            let header_name = match HeaderName::from_bytes(name.as_bytes()) {
+                                Ok(n) => n,
+                                Err(e) => {
+                                    let _ = response.send(Err(IoError::IoError(
+                                        format!("WebSocket connect failed: invalid header name '{}': {}", name, e),
+                                    )));
+                                    return;
+                                }
+                            };
+                            let header_value = match HeaderValue::from_str(value) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    let _ = response.send(Err(IoError::IoError(
+                                        format!("WebSocket connect failed: invalid header value for '{}': {}", name, e),
+                                    )));
+                                    return;
+                                }
+                            };
+                            req_headers.append(header_name, header_value);
+                        }
+
+                        match connect_async(request).await {
+                            Ok((ws_stream, _)) => {
+                                use futures::StreamExt;
+                                let (sender, receiver) = ws_stream.split();
+
+                                let handle = WS_CLIENT_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+                                ws_client_conns.lock().await.insert(handle, (sender, receiver));
+
                                 let _ = response.send(Ok(IoResponseValue::Int(handle as i64)));
                             }
                             Err(e) => {
@@ -3585,6 +3656,150 @@ mod tests {
         match result.unwrap() {
             IoResponseValue::HttpResponse { status, .. } => assert_eq!(status, 200),
             _ => panic!("Expected HttpResponse"),
+        }
+    }
+
+    /// Spawn a one-shot tungstenite WebSocket server on a free localhost port that
+    /// only completes the upgrade if the client sent `X-Test-Auth: secret`. Returns
+    /// the bound port and a JoinHandle for the dedicated tokio runtime thread that
+    /// runs the server.
+    ///
+    /// Used by the `connectWithHeaders` tests below. Lives in its own thread + tokio
+    /// runtime so it can run alongside the `IoRuntime`'s runtime without nesting.
+    fn spawn_header_checking_ws_server() -> (u16, std::thread::JoinHandle<bool>) {
+        use std::net::TcpListener as StdTcpListener;
+        use std::sync::mpsc;
+
+        // Bind synchronously so we know the port before the test thread proceeds.
+        let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind");
+        listener.set_nonblocking(true).expect("nonblock");
+        let port = listener.local_addr().unwrap().port();
+
+        let (ready_tx, ready_rx) = mpsc::channel::<()>();
+        let handle = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("server runtime");
+            rt.block_on(async move {
+                let listener = tokio::net::TcpListener::from_std(listener).expect("from_std");
+                let _ = ready_tx.send(());
+
+                // Accept a single TCP connection, then attempt the WS handshake
+                // while inspecting headers via accept_hdr_async.
+                let (stream, _) = match tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    listener.accept(),
+                ).await {
+                    Ok(Ok(pair)) => pair,
+                    _ => return false,
+                };
+
+                use tokio_tungstenite::tungstenite::handshake::server::{Request, Response, ErrorResponse};
+                use tokio_tungstenite::tungstenite::http::StatusCode;
+
+                let mut saw_header = false;
+                let callback = |req: &Request, resp: Response| -> Result<Response, ErrorResponse> {
+                    let auth = req.headers().get("X-Test-Auth").and_then(|v| v.to_str().ok());
+                    if auth == Some("secret") {
+                        saw_header = true;
+                        Ok(resp)
+                    } else {
+                        let mut err = ErrorResponse::new(Some("missing X-Test-Auth".into()));
+                        *err.status_mut() = StatusCode::UNAUTHORIZED;
+                        Err(err)
+                    }
+                };
+
+                match tokio_tungstenite::accept_hdr_async(stream, callback).await {
+                    Ok(_ws) => saw_header,
+                    Err(_) => false,
+                }
+            })
+        });
+
+        // Wait until the server thread has the listener attached.
+        let _ = ready_rx.recv_timeout(std::time::Duration::from_secs(2));
+        (port, handle)
+    }
+
+    #[test]
+    fn test_websocket_connect_rejected_without_required_header() {
+        let (port, server) = spawn_header_checking_ws_server();
+
+        let io = IoRuntime::new();
+        let tx = io.request_sender();
+
+        let (resp_tx, resp_rx) = oneshot::channel();
+        tx.send(IoRequest::WebSocketConnect {
+            url: format!("ws://127.0.0.1:{}/", port),
+            response: resp_tx,
+        }).unwrap();
+
+        let result = io.runtime.as_ref().unwrap().block_on(async {
+            resp_rx.await.unwrap()
+        });
+
+        // Without the header the server rejects with 401 and tungstenite turns
+        // that into a connect error.
+        assert!(result.is_err(), "expected WebSocketConnect to be rejected by header-checking server");
+
+        // The server returns false because it never saw the header.
+        let saw_header = server.join().expect("server thread");
+        assert!(!saw_header, "server should not have seen the header");
+    }
+
+    #[test]
+    fn test_websocket_connect_with_headers_passes_custom_header() {
+        let (port, server) = spawn_header_checking_ws_server();
+
+        let io = IoRuntime::new();
+        let tx = io.request_sender();
+
+        let (resp_tx, resp_rx) = oneshot::channel();
+        tx.send(IoRequest::WebSocketConnectWithHeaders {
+            url: format!("ws://127.0.0.1:{}/", port),
+            headers: vec![("X-Test-Auth".to_string(), "secret".to_string())],
+            response: resp_tx,
+        }).unwrap();
+
+        let result = io.runtime.as_ref().unwrap().block_on(async {
+            resp_rx.await.unwrap()
+        });
+
+        assert!(result.is_ok(), "expected connectWithHeaders to succeed: {:?}", result);
+        match result.unwrap() {
+            IoResponseValue::Int(handle) => assert!(handle > 0, "expected positive handle"),
+            other => panic!("expected Int handle, got {:?}", other),
+        }
+
+        let saw_header = server.join().expect("server thread");
+        assert!(saw_header, "server should have observed X-Test-Auth header");
+    }
+
+    #[test]
+    fn test_websocket_connect_with_headers_invalid_header_name_errors() {
+        // An invalid header name (contains a newline) must be reported as an
+        // IO error and must not panic the runtime.
+        let io = IoRuntime::new();
+        let tx = io.request_sender();
+
+        let (resp_tx, resp_rx) = oneshot::channel();
+        tx.send(IoRequest::WebSocketConnectWithHeaders {
+            url: "ws://127.0.0.1:1/".to_string(),
+            headers: vec![("Bad\nName".to_string(), "value".to_string())],
+            response: resp_tx,
+        }).unwrap();
+
+        let result = io.runtime.as_ref().unwrap().block_on(async {
+            resp_rx.await.unwrap()
+        });
+
+        match result {
+            Err(IoError::IoError(msg)) => {
+                assert!(msg.contains("invalid header name"), "expected invalid header name error, got: {}", msg);
+            }
+            other => panic!("expected invalid-header-name error, got {:?}", other),
         }
     }
 }

--- a/crates/vm/src/value.rs
+++ b/crates/vm/src/value.rs
@@ -1953,6 +1953,10 @@ pub enum Instruction {
     WebSocketAccept(Reg, Reg),
     /// Connect to WebSocket server: dst = WebSocket.connect(url)
     WebSocketConnect(Reg, Reg),
+    /// Connect to WebSocket server with custom HTTP headers on the upgrade:
+    /// dst = WebSocket.connectWithHeaders(url, headers)
+    /// headers: list of (name, value) tuples
+    WebSocketConnectWithHeaders(Reg, Reg, Reg),
     /// Send message on WebSocket: dst = WebSocket.send(request_id, message)
     WebSocketSend(Reg, Reg, Reg),
     /// Receive message from WebSocket: dst = WebSocket.receive(request_id)

--- a/docs/nostos-language-reference.md
+++ b/docs/nostos-language-reference.md
@@ -6501,6 +6501,30 @@ println("Got: " ++ response)
 WebSocket.close(ws)
 ```
 
+### Custom Headers on the Upgrade Request
+
+Use `WebSocket.connectWithHeaders` when the server requires HTTP headers on the
+WebSocket handshake (for example an `X-API-Key` or `Authorization` token):
+
+```nostos
+ws = WebSocket.connectWithHeaders(
+    "wss://api.example.com/feed",
+    [
+        ("X-API-Key", "secret"),
+        ("Authorization", "Bearer abc123"),
+    ]
+)
+WebSocket.send(ws, "subscribe")
+msg = WebSocket.recv(ws)
+WebSocket.close(ws)
+```
+
+The standard handshake headers (`Host`, `Upgrade`, `Connection`,
+`Sec-WebSocket-Key`, `Sec-WebSocket-Version`) are filled in automatically; the
+list you pass is appended on top. The function throws a `websocket_error`
+exception if the server rejects the upgrade or if a header name/value is
+invalid.
+
 ## Message Types
 
 ```nostos


### PR DESCRIPTION
## Summary

`WebSocket.connect` only accepts a URL, so Nostos clients cannot
authenticate against servers that require a header on the WebSocket
handshake (e.g. `X-API-Key`, `Authorization: Bearer ...`). This adds a
sibling builtin that takes a list of `(name, value)` tuples mirroring
`Http.request`:

```nostos
ws = WebSocket.connectWithHeaders(
    "wss://api.example.com/feed",
    [("X-API-Key", "secret"), ("Authorization", "Bearer abc123")]
)
```

The implementation threads through the existing layers:

- New builtin entry in the `BUILTINS` table and dispatch in both
  `WebSocket.*` match blocks in `crates/compiler/src/compile.rs`.
- New opcode `WebSocketConnectWithHeaders(dst, url, headers)` in
  `crates/vm/src/value.rs` and a corresponding handler in
  `crates/vm/src/async_vm.rs` that pulls the URL and
  `List[(String, String)]` out of registers (same extraction pattern
  as `Http.request`).
- New `IoRequest::WebSocketConnectWithHeaders` variant in
  `crates/vm/src/io_runtime.rs` that builds a tungstenite handshake
  request via `IntoClientRequest` and appends the user-supplied headers
  on top of the auto-generated ones (`Host`, `Upgrade`, `Connection`,
  `Sec-WebSocket-Key`, `Sec-WebSocket-Version`). Invalid header
  names/values surface as `websocket_error` exceptions rather than
  panicking the runtime.
- Small related cleanup: `WS_CLIENT_COUNTER` is now a single
  module-scope static so handles stay unique across both connect paths
  (previously each path declared its own function-scope `static`,
  which would eventually collide).

## Tests

Three new tests in `crates/vm/src/io_runtime.rs` (`mod tests`) drive
the new path against a self-contained tungstenite server in its own
tokio runtime that requires `X-Test-Auth: secret`:

- `test_websocket_connect_rejected_without_required_header` &mdash;
  baseline: `WebSocketConnect` (no headers) is rejected with 401.
- `test_websocket_connect_with_headers_passes_custom_header` &mdash;
  positive path: `connectWithHeaders` succeeds and the server observes
  the header.
- `test_websocket_connect_with_headers_invalid_header_name_errors`
  &mdash; malformed header names produce a clean `IoError`, not a panic.

## Documentation

`README.md` and `docs/nostos-language-reference.md` get a
`connectWithHeaders` example alongside the existing WebSocket client
section. No new files.

## Test plan

- [x] `cargo check --release --workspace --all-targets` passes locally.
- [x] CI on `hallyhaa:ws-connect-with-headers` (run [25608534026](https://github.com/hallyhaa/nostos/actions/runs/25608534026)) shows the same 4 pre-existing `nostos-jit` failures (`test_jit_fib_35`, `test_jit_fib_40`, `test_jit_fib_40_compiler_style`, `test_jit_fib_function`) that also fail on `pegesund:master` (run [25609987796](https://github.com/pegesund/nostos/actions/runs/25609987796)). They are unrelated to this change &mdash; both reproduce `JIT compilation failed: NotSuitable("non-tail self-recursion (CallSelf) not supported - would bypass stack overflow check")`. The `nostos-jit` failure aborts the suite before `nostos-vm`'s WebSocket tests get a chance to run on CI; running them locally requires a working OpenSSL toolchain (the WS client crate links `native-tls`).
- [ ] Manual smoke test against a server that requires a header on the WS upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)