### PR TITLE
Fix LSP false "not defined in module" diagnostic on valid imports

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -281,12 +281,20 @@ fn save_extension_to_cache(
         })
         .collect();
 
+    // Module exports: qualified names of this module's public functions, so a
+    // later cache hit can repopulate function_visibility via register_cached_module.
+    let exports: Vec<String> = compiler
+        .get_module_public_functions(ext_name)
+        .into_iter()
+        .map(|(_local_name, qualified_name)| qualified_name)
+        .collect();
+
     let cached_module = CachedModule {
         module_path: vec![ext_name.to_string()],
         source_hash: source_hash.to_string(),
         functions: cached_functions,
         function_signatures: std::collections::HashMap::new(),
-        exports: Vec::new(),
+        exports,
         prelude_imports: Vec::new(),
         types: module_types,
         mvars: module_mvars,
@@ -500,12 +508,20 @@ fn save_package_to_cache(
             })
             .collect();
 
+        // Module exports: qualified names of this module's public functions, so a
+        // later cache hit can repopulate function_visibility via register_cached_module.
+        let exports: Vec<String> = compiler
+            .get_module_public_functions(module_name)
+            .into_iter()
+            .map(|(_local_name, qualified_name)| qualified_name)
+            .collect();
+
         let cached_module = CachedModule {
             module_path: module_name.split('.').map(|s| s.to_string()).collect(),
             source_hash: source_hash.clone(),
             functions: cached_functions,
             function_signatures: std::collections::HashMap::new(),
-            exports: Vec::new(),
+            exports,
             prelude_imports: Vec::new(),
             types: module_types,
             mvars: module_mvars,
@@ -769,6 +785,14 @@ fn save_project_to_cache(
             module_name.clone()
         };
 
+        // Module exports: qualified names of this module's public functions, so a
+        // later cache hit can repopulate function_visibility via register_cached_module.
+        let exports: Vec<String> = compiler
+            .get_module_public_functions(module_name)
+            .into_iter()
+            .map(|(_local_name, qualified_name)| qualified_name)
+            .collect();
+
         let cached_module = CachedModule {
             module_path: if module_name.is_empty() {
                 vec![]
@@ -778,7 +802,7 @@ fn save_project_to_cache(
             source_hash: source_hash.clone(),
             functions: cached_functions,
             function_signatures: std::collections::HashMap::new(),
-            exports: Vec::new(),
+            exports,
             prelude_imports: Vec::new(),
             types: module_types,
             mvars: module_mvars,

--- a/crates/compiler/src/compile.rs
+++ b/crates/compiler/src/compile.rs
@@ -928,12 +928,14 @@ pub fn check_builtin_shadowing(name: &str) -> Option<(&'static str, &'static str
 /// myFunction(x) = x + 1
 /// ```
 pub fn extract_doc_comment(source: &str, span_start: usize) -> Option<String> {
-    if span_start == 0 || span_start > source.len() {
+    if span_start == 0 {
         return None;
     }
 
-    // Get the text before the span
-    let before = &source[..span_start];
+    // Get the text before the span. Use `str::get` so a span_start that
+    // lands inside a multi-byte UTF-8 character returns None instead of
+    // panicking. Length and char-boundary are both verified by `get`.
+    let before = source.get(..span_start)?;
 
     // Find all lines before the definition
     let lines: Vec<&str> = before.lines().collect();
@@ -11107,13 +11109,14 @@ impl Compiler {
         // Use accumulated debug symbols (not affected by block scope restoration)
         let debug_symbols = std::mem::take(&mut self.current_fn_debug_symbols);
 
-        // Extract source code for this function from the source
+        // Extract source code for this function from the source. Use
+        // `str::get` rather than direct slicing so a span that lands inside
+        // a multi-byte UTF-8 character (e.g. an em-dash in a doc comment)
+        // yields None instead of panicking. The bounds-only guard the
+        // earlier code used was not enough -- byte indices in range can
+        // still cut a codepoint in half.
         let source_code = self.current_source.as_ref().and_then(|src| {
-            if def.span.start < src.len() && def.span.end <= src.len() {
-                Some(Arc::new(src[def.span.start..def.span.end].to_string()))
-            } else {
-                None
-            }
+            src.get(def.span.start..def.span.end).map(|s| Arc::new(s.to_string()))
         });
 
         // Extract doc comment from source (comment lines immediately before the function)
@@ -34511,6 +34514,23 @@ mod tests {
         let span_start = source.find("main").unwrap();
         let doc = extract_doc_comment(source, span_start);
         assert_eq!(doc, None);
+    }
+
+    /// Regression test: a span_start that lands inside a multi-byte UTF-8
+    /// character (here, between the bytes of an em-dash `─`) must not panic.
+    /// Before the str::get fix, `&source[..span_start]` would panic with
+    /// "byte index N is not a char boundary".
+    #[test]
+    fn test_extract_doc_comment_mid_codepoint_does_not_panic() {
+        let source = "# A box drawing char ─ in a comment\nmain() = 42";
+        let em_dash = source.find('─').unwrap();
+        // Aim for the middle byte of the 3-byte `─` codepoint.
+        let mid_codepoint = em_dash + 1;
+        assert!(!source.is_char_boundary(mid_codepoint));
+        // Must return None rather than panic. The behaviour at a non-boundary
+        // index is "no doc comment available", which is what the rest of the
+        // codebase expects from this helper.
+        assert_eq!(extract_doc_comment(source, mid_codepoint), None);
     }
 
     #[test]

--- a/crates/compiler/src/compile.rs
+++ b/crates/compiler/src/compile.rs
@@ -26319,13 +26319,6 @@ scope_depth: self.block_depth,
         self.function_visibility.insert(name.to_string(), visibility);
     }
 
-    /// Iterate over all registered function visibility entries.
-    /// Used to copy visibility into a throw-away analysis compiler so that
-    /// cross-module `use` imports can be resolved during read-only checking.
-    pub fn get_all_function_visibility(&self) -> impl Iterator<Item = (&String, &Visibility)> {
-        self.function_visibility.iter()
-    }
-
     /// Register all external functions at once, preserving their indices.
     /// This is important for eval because compiled bytecode contains CallDirect
     /// instructions with hardcoded function indices that must be preserved.
@@ -34354,7 +34347,14 @@ impl Compiler {
                     let mut resolved_qualified_name = qualified_name.clone();
                     if !is_stdlib_module {
                         let fn_prefix = format!("{}/", qualified_name);
+                        // Check both function_visibility and the function table. Functions
+                        // registered into a compiler externally (register_external_functions_with_list,
+                        // used by the LSP's read-only check) populate `functions` but not
+                        // `function_visibility`; consulting only the latter would wrongly flag a
+                        // valid cross-module import as undefined.
                         let exists_as_function = self.function_visibility.keys().any(|k| {
+                            k == &qualified_name || k.starts_with(&fn_prefix)
+                        }) || self.functions.keys().any(|k| {
                             k == &qualified_name || k.starts_with(&fn_prefix)
                         });
                         let exists_as_type = self.type_visibility.contains_key(&qualified_name);

--- a/crates/compiler/src/compile.rs
+++ b/crates/compiler/src/compile.rs
@@ -26319,6 +26319,13 @@ scope_depth: self.block_depth,
         self.function_visibility.insert(name.to_string(), visibility);
     }
 
+    /// Iterate over all registered function visibility entries.
+    /// Used to copy visibility into a throw-away analysis compiler so that
+    /// cross-module `use` imports can be resolved during read-only checking.
+    pub fn get_all_function_visibility(&self) -> impl Iterator<Item = (&String, &Visibility)> {
+        self.function_visibility.iter()
+    }
+
     /// Register all external functions at once, preserving their indices.
     /// This is important for eval because compiled bytecode contains CallDirect
     /// instructions with hardcoded function indices that must be preserved.
@@ -27259,6 +27266,25 @@ scope_depth: self.block_depth,
     /// Get all known module prefixes.
     pub fn get_known_modules(&self) -> impl Iterator<Item = &str> {
         self.known_modules.iter().map(|s| s.as_str())
+    }
+
+    /// Get known module names that have no resolvable public symbols registered.
+    ///
+    /// Such a module was referenced but never fully analyzed — for example,
+    /// restored from an incomplete bytecode cache. Imports from it cannot be
+    /// resolved, so a "symbol is not defined in module" diagnostic against the
+    /// import would be misleading rather than helpful.
+    pub fn get_known_modules_without_public_symbols(&self) -> std::collections::HashSet<String> {
+        let mut result = std::collections::HashSet::new();
+        for module in &self.known_modules {
+            let prefix = format!("{}.", module);
+            let has_function = self.function_visibility.keys().any(|k| k.starts_with(&prefix));
+            let has_type = self.type_visibility.keys().any(|k| k.starts_with(&prefix));
+            if !has_function && !has_type {
+                result.insert(module.clone());
+            }
+        }
+        result
     }
 
     /// Debug function to check what arities exist for a function name

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -521,7 +521,7 @@ impl NostosLanguageServer {
             return diagnostics;
         }
 
-        diagnostics.into_iter().filter_map(|mut d| {
+        diagnostics.into_iter().map(|mut d| {
             // Pattern: "`symbol` is not defined in module `modulename`"
             if d.message.contains("is not defined in module") {
                 // Extract the module name from the error message
@@ -534,20 +534,17 @@ impl NostosLanguageServer {
                             // Replace with a clearer message
                             d.message = format!("module `{}` failed to compile — see errors in {}.nos", module_name, module_name);
                             d.severity = Some(DiagnosticSeverity::WARNING);
-                            return Some(d);
-                        }
-                        if unanalyzed_modules.contains(module_name) {
+                        } else if unanalyzed_modules.contains(module_name) {
                             d.message = format!(
                                 "module `{}` has not been fully analyzed yet — this import is probably valid; rebuilding usually clears this",
                                 module_name
                             );
                             d.severity = Some(DiagnosticSeverity::WARNING);
-                            return Some(d);
                         }
                     }
                 }
             }
-            Some(d)
+            d
         }).collect()
     }
 

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -194,7 +194,7 @@ impl NostosLanguageServer {
 
         // Use check_module_compiles which does NOT modify the engine state
         // This is a read-only analysis for real-time feedback
-        let (result, failed_modules) = {
+        let (result, failed_modules, unanalyzed_modules) = {
             let engine_guard = self.engine.lock().unwrap();
             let Some(engine) = engine_guard.as_ref() else {
                 debug!("check_file: engine not ready yet after waiting, skipping check");
@@ -203,7 +203,8 @@ impl NostosLanguageServer {
 
             let r = engine.check_module_compiles(&module_name, content);
             let fm = engine.get_failed_modules();
-            (r, fm)
+            let um = engine.get_unanalyzed_modules();
+            (r, fm, um)
         };
 
         trace!("Check result for {}: {:?}", module_name, result);
@@ -228,7 +229,7 @@ impl NostosLanguageServer {
         };
 
         // Filter out cascading import errors from failed modules
-        let error_diagnostics = Self::filter_cascading_import_errors(error_diagnostics, &failed_modules);
+        let error_diagnostics = Self::filter_cascading_import_errors(error_diagnostics, &failed_modules, &unanalyzed_modules);
 
         // Store error diagnostics for this file
         self.file_errors.insert(uri.clone(), error_diagnostics.clone());
@@ -321,11 +322,14 @@ impl NostosLanguageServer {
         };
 
         // Filter out cascading import errors from failed modules
-        let failed_modules = {
+        let (failed_modules, unanalyzed_modules) = {
             let engine_guard = self.engine.lock().unwrap();
-            engine_guard.as_ref().map(|e| e.get_failed_modules()).unwrap_or_default()
+            match engine_guard.as_ref() {
+                Some(e) => (e.get_failed_modules(), e.get_unanalyzed_modules()),
+                None => Default::default(),
+            }
         };
-        let error_diagnostics = Self::filter_cascading_import_errors(error_diagnostics, &failed_modules);
+        let error_diagnostics = Self::filter_cascading_import_errors(error_diagnostics, &failed_modules, &unanalyzed_modules);
 
         // Store error diagnostics for this file (so we can merge with stale warnings later)
         self.file_errors.insert(uri.clone(), error_diagnostics.clone());
@@ -392,11 +396,14 @@ impl NostosLanguageServer {
             };
 
             // Filter cascading import errors from failed modules
-            let failed_modules = {
+            let (failed_modules, unanalyzed_modules) = {
                 let engine_guard = self.engine.lock().unwrap();
-                engine_guard.as_ref().map(|e| e.get_failed_modules()).unwrap_or_default()
+                match engine_guard.as_ref() {
+                    Some(e) => (e.get_failed_modules(), e.get_unanalyzed_modules()),
+                    None => Default::default(),
+                }
             };
-            let error_diagnostics = Self::filter_cascading_import_errors(error_diagnostics, &failed_modules);
+            let error_diagnostics = Self::filter_cascading_import_errors(error_diagnostics, &failed_modules, &unanalyzed_modules);
 
             self.file_errors.insert(uri.clone(), error_diagnostics.clone());
             self.client.publish_diagnostics(uri, error_diagnostics, None).await;
@@ -494,12 +501,23 @@ impl NostosLanguageServer {
         (0, error_msg.to_string())
     }
 
-    /// Filter out cascading import errors caused by a dependency module failing to compile.
-    /// When module B has errors, importing from B produces "`X` is not defined in module `B`".
-    /// This is misleading — the real problem is in B, not in the import statement.
-    /// We replace such diagnostics with a clearer message pointing at the failed module.
-    fn filter_cascading_import_errors(diagnostics: Vec<Diagnostic>, failed_modules: &std::collections::HashSet<String>) -> Vec<Diagnostic> {
-        if failed_modules.is_empty() {
+    /// Filter out misleading cascading import diagnostics.
+    ///
+    /// When module B cannot be resolved, importing from B produces
+    /// "`X` is not defined in module `B`". This is misleading — the real
+    /// problem is not the import statement. Two cases are downgraded:
+    ///
+    /// - `failed_modules`: B exists but failed to compile. The user should be
+    ///   pointed at B's real error.
+    /// - `unanalyzed_modules`: B is known but was never fully analyzed (for
+    ///   example, restored from an incomplete bytecode cache). The import is
+    ///   probably valid; a rebuild usually resolves it.
+    fn filter_cascading_import_errors(
+        diagnostics: Vec<Diagnostic>,
+        failed_modules: &std::collections::HashSet<String>,
+        unanalyzed_modules: &std::collections::HashSet<String>,
+    ) -> Vec<Diagnostic> {
+        if failed_modules.is_empty() && unanalyzed_modules.is_empty() {
             return diagnostics;
         }
 
@@ -515,6 +533,14 @@ impl NostosLanguageServer {
                         if failed_modules.contains(module_name) {
                             // Replace with a clearer message
                             d.message = format!("module `{}` failed to compile — see errors in {}.nos", module_name, module_name);
+                            d.severity = Some(DiagnosticSeverity::WARNING);
+                            return Some(d);
+                        }
+                        if unanalyzed_modules.contains(module_name) {
+                            d.message = format!(
+                                "module `{}` has not been fully analyzed yet — this import is probably valid; rebuilding usually clears this",
+                                module_name
+                            );
                             d.severity = Some(DiagnosticSeverity::WARNING);
                             return Some(d);
                         }
@@ -735,6 +761,7 @@ impl LanguageServer for NostosLanguageServer {
                     // Collect errors and failed modules before storing engine
                     let error_defs = engine.get_error_definitions();
                     let failed_modules = engine.get_failed_modules();
+                    let unanalyzed_modules = engine.get_unanalyzed_modules();
                     let root = self.root_path.lock().unwrap().clone();
 
                     *self.engine.lock().unwrap() = Some(engine);
@@ -774,7 +801,7 @@ impl LanguageServer for NostosLanguageServer {
                                         };
 
                                         // Filter cascading import errors
-                                        let filtered = Self::filter_cascading_import_errors(vec![diagnostic], &failed_modules);
+                                        let filtered = Self::filter_cascading_import_errors(vec![diagnostic], &failed_modules, &unanalyzed_modules);
 
                                         // Store in file_errors for persistence
                                         self.file_errors.insert(uri.clone(), filtered.clone());

--- a/crates/lsp/tests/integration_test.rs
+++ b/crates/lsp/tests/integration_test.rs
@@ -5970,3 +5970,73 @@ fn test_rename_capability_advertised() {
     client.exit();
     cleanup_test_project(&project_path);
 }
+
+/// Regression test for the cascading "not defined in module" false positive.
+///
+/// A valid `use lib.{...}` import must not be flagged as undefined after a
+/// transient parse error in the importing file is introduced and reverted.
+/// Before the fix, the throw-away analysis compiler lacked function visibility
+/// for the imported module, so the import was wrongly reported as undefined.
+#[test]
+fn test_lsp_no_false_cascading_import_error() {
+    let project_path = create_test_project("cascading_import");
+
+    // A module with two genuinely-defined, public functions.
+    fs::write(
+        project_path.join("lib.nos"),
+        "pub answer() = 42\npub double(x) = x + x\n",
+    ).unwrap();
+
+    let valid_content = "use lib.{answer, double}\n\nmain() = double(answer())\n";
+    // The same file with `use` mistyped as `usse` — a parse error on line 1.
+    let broken_content = "usse lib.{answer, double}\n\nmain() = double(answer())\n";
+
+    fs::write(project_path.join("main.nos"), valid_content).unwrap();
+
+    let mut client = LspClient::new(&require_lsp_binary!());
+    let _ = client.initialize(project_path.to_str().unwrap());
+    client.initialized_and_wait();
+
+    let main_uri = format!("file://{}/main.nos", project_path.display());
+    client.did_open(&main_uri, valid_content);
+
+    // Initial state: the import is valid, so it must not be flagged.
+    std::thread::sleep(Duration::from_millis(400));
+    let initial_diags = client.read_diagnostics(&main_uri, Duration::from_secs(2));
+    println!("=== Initial diagnostics ===");
+    for d in &initial_diags {
+        println!("  Line {}: {}", d.line + 1, d.message);
+    }
+    assert!(
+        !initial_diags.iter().any(|d| d.message.contains("is not defined in module")),
+        "Valid import wrongly flagged on initial open: {:?}",
+        initial_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    // Introduce a transient parse error: `use` -> `usse`. This produces one
+    // diagnostics batch (the parse error), which we read and discard.
+    client.did_change(&main_uri, broken_content, 2);
+    std::thread::sleep(Duration::from_millis(500));
+    let _ = client.read_diagnostics(&main_uri, Duration::from_secs(3));
+
+    // Revert back to the valid import. The LSP publishes exactly one
+    // diagnostics batch per didChange — this batch is the reverted state.
+    client.did_change(&main_uri, valid_content, 3);
+    std::thread::sleep(Duration::from_millis(600));
+    let post_revert = client.read_diagnostics(&main_uri, Duration::from_secs(3));
+    println!("=== Diagnostics after usse -> use round-trip ===");
+    for d in &post_revert {
+        println!("  Line {}: {}", d.line + 1, d.message);
+    }
+
+    let _ = client.shutdown();
+    client.exit();
+    cleanup_test_project(&project_path);
+
+    assert!(
+        !post_revert.iter().any(|d| d.message.contains("is not defined in module")),
+        "After reverting a transient parse error, the valid `use lib.{{...}}` import \
+         was wrongly flagged as undefined: {:?}",
+        post_revert.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/repl/src/engine.rs
+++ b/crates/repl/src/engine.rs
@@ -7972,7 +7972,7 @@ impl ReplEngine {
         // import-existence check consults only function_visibility — so without this, every
         // cross-module `use mod.{func}` import would be wrongly flagged as undefined.
         for (name, visibility) in self.compiler.get_all_function_visibility() {
-            check_compiler.register_function_visibility(name, visibility.clone());
+            check_compiler.register_function_visibility(name, *visibility);
         }
 
         // Register external types from the main compiler

--- a/crates/repl/src/engine.rs
+++ b/crates/repl/src/engine.rs
@@ -5437,8 +5437,16 @@ impl ReplEngine {
                             })
                             .collect();
 
-                        // Get module exports (for now, empty - TODO: extract from compiler)
-                        let exports = Vec::new();
+                        // Get module exports: the qualified names of this module's
+                        // public functions. These are needed so that a later cache
+                        // hit can repopulate function_visibility via
+                        // register_cached_module — otherwise imports from a
+                        // cache-restored module resolve to nothing.
+                        let exports: Vec<String> = self.compiler
+                            .get_module_public_functions(&module_name)
+                            .into_iter()
+                            .map(|(_local_name, qualified_name)| qualified_name)
+                            .collect();
 
                         // Get dependencies from call graph
                         let dependencies: Vec<String> = self.call_graph.direct_dependencies(&module_name)
@@ -7959,6 +7967,14 @@ impl ReplEngine {
         let func_list = self.compiler.get_function_list_names();
         check_compiler.register_external_functions_with_list(all_funcs, func_list);
 
+        // Copy function visibility from the main compiler. register_external_functions_with_list
+        // populates the function tables but not function_visibility, and compile_use_stmt's
+        // import-existence check consults only function_visibility — so without this, every
+        // cross-module `use mod.{func}` import would be wrongly flagged as undefined.
+        for (name, visibility) in self.compiler.get_all_function_visibility() {
+            check_compiler.register_function_visibility(name, visibility.clone());
+        }
+
         // Register external types from the main compiler
         for (name, type_val) in self.compiler.get_all_types() {
             check_compiler.register_external_type(&name, &type_val);
@@ -8183,6 +8199,16 @@ impl ReplEngine {
             }
         }
         failed
+    }
+
+    /// Get known modules that have no resolvable public symbols.
+    ///
+    /// Such a module was referenced but never fully analyzed (for example,
+    /// restored from an incomplete bytecode cache). Imports from it cannot be
+    /// resolved, so the LSP downgrades any "symbol is not defined in module"
+    /// diagnostic against such an import rather than showing a misleading error.
+    pub fn get_unanalyzed_modules(&self) -> std::collections::HashSet<String> {
+        self.compiler.get_known_modules_without_public_symbols()
     }
 
     /// Get all stale definitions

--- a/crates/repl/src/engine.rs
+++ b/crates/repl/src/engine.rs
@@ -7967,14 +7967,6 @@ impl ReplEngine {
         let func_list = self.compiler.get_function_list_names();
         check_compiler.register_external_functions_with_list(all_funcs, func_list);
 
-        // Copy function visibility from the main compiler. register_external_functions_with_list
-        // populates the function tables but not function_visibility, and compile_use_stmt's
-        // import-existence check consults only function_visibility — so without this, every
-        // cross-module `use mod.{func}` import would be wrongly flagged as undefined.
-        for (name, visibility) in self.compiler.get_all_function_visibility() {
-            check_compiler.register_function_visibility(name, *visibility);
-        }
-
         // Register external types from the main compiler
         for (name, type_val) in self.compiler.get_all_types() {
             check_compiler.register_external_type(&name, &type_val);

--- a/crates/vm/src/cache.rs
+++ b/crates/vm/src/cache.rs
@@ -176,6 +176,17 @@ use crate::value::TypeValue;
 // Cache Manifest
 // ============================================================================
 
+/// Current on-disk cache format version.
+///
+/// Bump this whenever the serialized shape or semantics of a cached module
+/// change in a way that makes older caches unsafe to read. `is_cache_valid`
+/// rejects any manifest whose `format_version` differs, so stale caches are
+/// transparently rebuilt instead of being loaded in a degraded state.
+///
+/// Version 2: `CachedModule.exports` is now populated with the module's public
+/// functions (it was always empty in version 1).
+pub const CACHE_FORMAT_VERSION: u32 = 2;
+
 /// Global cache manifest tracking all cached modules
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CacheManifest {
@@ -196,7 +207,7 @@ pub struct ModuleCacheInfo {
 impl CacheManifest {
     pub fn new(compiler_version: &str) -> Self {
         Self {
-            format_version: 1,
+            format_version: CACHE_FORMAT_VERSION,
             compiler_version: compiler_version.to_string(),
             modules: HashMap::new(),
             dependency_graph: HashMap::new(),
@@ -578,6 +589,11 @@ pub fn is_cache_valid(
     source_path: &Path,
     compiler_version: &str,
 ) -> bool {
+    // Reject caches written in an older on-disk format
+    if manifest.format_version != CACHE_FORMAT_VERSION {
+        return false;
+    }
+
     // Check compiler version
     if manifest.compiler_version != compiler_version {
         return false;

--- a/crates/vm/tests/cache_tests.rs
+++ b/crates/vm/tests/cache_tests.rs
@@ -7,7 +7,7 @@
 
 use std::path::Path;
 use std::collections::HashMap;
-use nostos_vm::cache::{load_module_cache, save_module_cache, CachedModule, BytecodeCache, FunctionSignature};
+use nostos_vm::cache::{load_module_cache, save_module_cache, CachedModule, BytecodeCache, FunctionSignature, CACHE_FORMAT_VERSION};
 
 /// Helper to compute source hash (same algorithm as compiler)
 fn compute_source_hash(content: &str) -> String {
@@ -319,7 +319,7 @@ fn test_dependency_graph_tracking() {
 
     // Verify the manifest structure exists
     let manifest = cache.manifest();
-    assert_eq!(manifest.format_version, 1);
+    assert_eq!(manifest.format_version, CACHE_FORMAT_VERSION);
     assert_eq!(manifest.compiler_version, "test-0.1.0");
     assert!(manifest.dependency_graph.is_empty(), "Should start with empty graph");
 


### PR DESCRIPTION
## Summary

A valid `use mod.{func}` import was wrongly flagged as
`` `func` is not defined in module `mod` `` whenever the importing file had a
transient parse error that was then reverted (for example, a typo corrected).
The wrong error stuck and reappeared on every edit round-trip, and deleting
`.nostos-cache/` was the only workaround.

## Root causes

Two independent defects:

1. **The import-existence check ignored externally-registered functions.**
   `compile_use_stmt` decided whether an imported symbol exists by consulting
   only `function_visibility`. Functions registered into a compiler via
   `register_external_functions_with_list` (used by the LSP's read-only
   `check_module_compiles`) populate the `functions` table but not
   `function_visibility`, so every cross-module function import failed the
   check. Imported types worked, because the type registration path does
   populate `type_visibility`; that asymmetry was the tell. The existence
   check now also consults the `functions` table.

2. **The bytecode cache stored empty module exports.** `CachedModule.exports`
   was always `Vec::new()`, so a cache-restored module registered no public
   functions via `register_cached_module`. `exports` is now populated with the
   module's public functions at all four construction sites, and
   `CACHE_FORMAT_VERSION` is bumped to 2 so stale v1 caches are rebuilt instead
   of being read in the degraded state.

As defense in depth, `filter_cascading_import_errors` now also downgrades the
diagnostic for modules that are known but have no resolvable public symbols
(`get_unanalyzed_modules`).

This is the cascading-error case that #36's suppression did not catch: the
dependency module ends up in a "not analyzed / empty exports" state rather than
a "failed to compile" state, so it is not in `get_failed_modules()`.

## Minimal example

A two-file project where `main.nos` imports two genuinely-defined `pub`
functions from `lib.nos`. `nostos .` compiles and runs it cleanly (prints `84`).

`nostos.toml`
```toml
[project]
name = "minimal_example"
version = "0.1.0"
```

`lib.nos`
```
# A module that exports two public functions.
# Both are genuinely defined and `pub`, so importing them is valid.

pub answer() = 42

pub double(x) = x + x
```

`main.nos`
```
use lib.{answer, double}

main() = double(answer())
```

### Reproducing in an editor (via nostos-lsp)

1. Delete any `.nostos-cache/` directory so you start fresh.
2. Open the project in an editor backed by `nostos-lsp`. Open `main.nos`.
3. On line 1 of `main.nos`, change `use` to `usse` (an intentional typo). A
   parse error appears on line 1.
4. Change `usse` back to `use`. The parse error clears, but a red error appears:
   `` `answer` is not defined in module `lib` ``, even though the import is
   valid. Deleting `.nostos-cache/` clears it only until the next round-trip.

## Testing

- New LSP integration regression test `test_lsp_no_false_cascading_import_error`
  covering the `use`/`usse` round-trip.
- Verified the test **fails** on the unfixed base
  (`` `answer` is not defined in module `lib` ``) and **passes** with the fix.
- Full suites green: 406 compiler tests, 523 repl tests, the vm cache tests,
  and 88 LSP integration tests.

Relates to #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
