### PR TITLE
Show "auto" instead of raw inference variables in LSP hover

### DIFF
--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -1415,7 +1415,7 @@ impl LanguageServer for NostosLanguageServer {
                     use std::io::Write;
                     let _ = writeln!(f, "LHS binding fast path: {} = {}", word, ty);
                 }
-                let info = format!("```nostos\n{}: {}\n```\n*(inferred)*", word, ty);
+                let info = format!("```nostos\n{}: {}\n```\n*(inferred)*", word, Self::sanitize_signature_type_vars(ty));
                 drop(engine_guard);
                 return Ok(Some(Hover {
                     contents: HoverContents::Markup(MarkupContent {
@@ -1486,23 +1486,23 @@ impl LanguageServer for NostosLanguageServer {
             if let Some(engine) = engine_ref {
                 self.get_hover_info(engine, &word, &local_vars, line)
                     .or_else(|| hm_type.as_ref().map(|ty| {
-                        format!("```nostos\n{}: {}\n```\n*(inferred)*", word, ty)
+                        format!("```nostos\n{}: {}\n```\n*(inferred)*", word, Self::sanitize_signature_type_vars(ty))
                     }))
             } else {
                 hm_type.as_ref().map(|ty| {
-                    format!("```nostos\n{}: {}\n```\n*(inferred)*", word, ty)
+                    format!("```nostos\n{}: {}\n```\n*(inferred)*", word, Self::sanitize_signature_type_vars(ty))
                 })
             }
         } else if let Some(ty) = &hm_type {
             if !ty.contains('?') {
                 // Got a clean HM-inferred type - use it
-                Some(format!("```nostos\n{}: {}\n```\n*(inferred)*", word, ty))
+                Some(format!("```nostos\n{}: {}\n```\n*(inferred)*", word, Self::sanitize_signature_type_vars(ty)))
             } else if let Some(engine) = engine_ref {
                 // Type has unresolved vars - try fallback
                 self.get_hover_info(engine, &word, &local_vars, line)
-                    .or_else(|| Some(format!("```nostos\n{}: {}\n```\n*(inferred)*", word, ty)))
+                    .or_else(|| Some(format!("```nostos\n{}: {}\n```\n*(inferred)*", word, Self::sanitize_signature_type_vars(ty))))
             } else {
-                Some(format!("```nostos\n{}: {}\n```\n*(inferred)*", word, ty))
+                Some(format!("```nostos\n{}: {}\n```\n*(inferred)*", word, Self::sanitize_signature_type_vars(ty)))
             }
         } else if let Some(engine) = engine_ref {
             self.get_hover_info(engine, &word, &local_vars, line)
@@ -4998,7 +4998,7 @@ impl NostosLanguageServer {
 
         // Try to infer expression type
         if let Some(ty) = engine.infer_expression_type(word, local_vars) {
-            return Some(format!("```nostos\n{}: {}\n```\n*(inferred)*", word, ty));
+            return Some(format!("```nostos\n{}: {}\n```\n*(inferred)*", word, Self::sanitize_signature_type_vars(&ty)));
         }
 
         None

--- a/crates/lsp/tests/integration_test.rs
+++ b/crates/lsp/tests/integration_test.rs
@@ -7468,3 +7468,38 @@ fn test_workspace_symbols_no_match() {
     client.exit();
     cleanup_test_project(&project_path);
 }
+
+/// Regression: hovering an unannotated parameter that inference leaves as a
+/// polymorphic (Concat-bounded) type variable must show a friendly "auto"
+/// rather than a raw inference variable like `?2451`.
+#[test]
+fn test_lsp_hover_polymorphic_param_shows_auto() {
+    let project_path = create_test_project("hover_poly_param");
+
+    // `source` is unannotated; `++` only adds a `Concat` bound, so inference
+    // leaves it as an unresolved type variable rather than a concrete type.
+    let main_content = "fmt(source, message) = source ++ \" - \" ++ message\n";
+    fs::write(project_path.join("main.nos"), main_content).unwrap();
+
+    let mut client = LspClient::new(&require_lsp_binary!());
+    let _ = client.initialize(project_path.to_str().unwrap());
+    client.initialized_and_wait();
+
+    let main_uri = format!("file://{}/main.nos", project_path.display());
+    client.did_open(&main_uri, main_content);
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Hover over the `source` use in the body (col 23 begins "source").
+    let hover = client.hover(&main_uri, 0, 25);
+    println!("hover for `source`: {:?}", hover);
+    let text = hover.expect("expected hover info for `source`");
+    assert!(
+        !text.contains('?'),
+        "hover must not expose a raw inference variable like ?N, got: {}",
+        text
+    );
+
+    let _ = client.shutdown();
+    client.exit();
+    cleanup_test_project(&project_path);
+}


### PR DESCRIPTION
## Summary
`textDocument/hover` rendered an unannotated, still-polymorphic binding's type as a raw inference variable (e.g. `?2451`), which shows up in editors as confusing noise (reported from an IntelliJ plugin hovering a logging helper's `source`/`message` params).

These parameters are genuinely polymorphic: `++` only adds a `Concat` bound and `println` is `Show a => a -> ()`, so inference correctly leaves them as a type variable. The problem was purely in how hover *displays* that variable.

`signatureHelp` already sanitizes unresolved type variables to `auto` via `sanitize_signature_type_vars`; the hover path did not. This change applies the same sanitization at every hover type-formatting site, so such a parameter reads as `auto` instead of `?N`.

## Changes
- `crates/lsp/src/server.rs`: run the hover type string through `sanitize_signature_type_vars` at all `*(inferred)*` formatting sites (consistent with signatureHelp).
- `crates/lsp/tests/integration_test.rs`: add `test_lsp_hover_polymorphic_param_shows_auto`, which hovers a parameter constrained only by a `++` (Concat) bound and asserts the hover never exposes a raw `?N`.

## Note on wording
I reused the existing `auto` label for consistency with signatureHelp, but feel free to pick different wording (e.g. `a`, or surfacing the bound as `Concat a => a`) — it's a one-line change in `sanitize_signature_type_vars`.

## Test plan
- [x] `cargo test -p nostos-lsp` — 112 passed, 0 failed (new test included)
- [x] Manually verified hover now shows `source: auto` instead of `?101`

🤖 Generated with [Claude Code](https://claude.com/claude-code)